### PR TITLE
Add modules for Python 2.5-7

### DIFF
--- a/main/python/2.5.6
+++ b/main/python/2.5.6
@@ -1,6 +1,6 @@
 #%Module1.0#####################################################################
 ##
-## Python3 modulefile
+## Python2.5 modulefile
 ##
 proc ModulesHelp { } {
         global version prefix

--- a/main/python/2.6.8
+++ b/main/python/2.6.8
@@ -1,6 +1,6 @@
 #%Module1.0#####################################################################
 ##
-## Python3 modulefile
+## Python2.6 modulefile
 ##
 proc ModulesHelp { } {
         global version prefix

--- a/main/python/2.7.3
+++ b/main/python/2.7.3
@@ -1,6 +1,6 @@
 #%Module1.0#####################################################################
 ##
-## Python3 modulefile
+## Python2.7 modulefile
 ##
 proc ModulesHelp { } {
         global version prefix


### PR DESCRIPTION
Includes module files for python 2.5.6, 2.6.8, and 2.7.3.
