### PR TITLE
Update 2.3.9

### DIFF
--- a/varscan/2.3.9
+++ b/varscan/2.3.9
@@ -21,6 +21,6 @@ set	datarootdir	${prefix}/share
 
 
 prepend-path    PATH            ${iigb_modules}/varscan/2.3.9/scripts
-setenv		VARSCANHOME	/opt/varscan/2.3.9
-setenv		VARSCANJAR	/opt/varscan/2.3.9/VarScan.jar
+setenv		VARSCANHOME	${iigb_modules}/varscan/2.3.9
+setenv		VARSCANJAR	${iigb_modules}/varscan/2.3.9/VarScan.jar
 module		use		${modules_dir}


### PR DESCRIPTION
I think this should be updated to use the module dir with the env variable not the previously harcoded /opt/varscan?  Don't you agree - was this just an oversight?
